### PR TITLE
CardCollection 구현

### DIFF
--- a/Assets/Scripts/Card/CardCollection.cs
+++ b/Assets/Scripts/Card/CardCollection.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TeamOdd.Ratocalypse.Card
+{
+    public class CardCollection : IEnumerable<CardData>
+    {
+        protected readonly List<CardData> _cardList;
+
+        public CardCollection(params CardData[] cardDataItems)
+        {
+            _cardList = cardDataItems.ToList();
+        }
+
+        public int Count { get => _cardList.Count; }
+
+        public CardData GetCard(int index)
+        {
+            return _cardList[index];
+        }
+
+        public void AddCard(CardData cardData)
+        {
+            _cardList.Add(cardData);
+        }
+
+        public void AddCards(params CardData[] cardDataItems)
+        {
+            foreach (CardData cardData in cardDataItems)
+            {
+                AddCard(cardData);
+            }
+        }
+        public void RemoveCard(int index)
+        {
+            _cardList.RemoveAt(index);
+        }
+
+        public void RemoveCards(ISet<int> indices)
+        {
+            SortedSet<int> sortedIndices = new SortedSet<int>(indices);
+            foreach (int i in sortedIndices.Reverse())
+            {
+                _cardList.RemoveAt(i);
+            }
+        }
+
+        public IEnumerator<CardData> GetEnumerator()
+        {
+            return _cardList.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Assets/Scripts/Card/CardCollection.cs.meta
+++ b/Assets/Scripts/Card/CardCollection.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc19b727cc3b3f040ac90e7c38fb6fe4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Card/Deck.cs
+++ b/Assets/Scripts/Card/Deck.cs
@@ -1,41 +1,7 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace TeamOdd.Ratocalypse.Card
 {
-    public class Deck
+    public class Deck : CardCollection
     {
-        private List<CardData> _cardList;
-
-        public Deck(params CardData[] cardDatas)
-        {
-            _cardList = cardDatas.ToList();
-        }
-
-        public int Count { get => _cardList.Count; }
-
-        public CardData GetCard(int index)
-        {
-            return _cardList[index];
-        }
-
-        public void AddCard(CardData cardData)
-        {
-            _cardList.Add(cardData);
-        }
-
-        public void RemoveCards(ISet<int> indices)
-        {
-            SortedSet<int> sortedIndices = new SortedSet<int>(indices);
-            foreach (int i in sortedIndices.Reverse())
-            {
-                _cardList.RemoveAt(i);
-            }
-        }
-
-        public void RemoveCard(int index)
-        {
-            _cardList.RemoveAt(index);
-        }
+        public Deck(params CardData[] cardDataItems) : base(cardDataItems) { }
     }
 }


### PR DESCRIPTION
CardCollection 카드 저장/제거/꺼내기
- 무덤 기능과 덱 기능이 겹쳐 카드를 저장하고 꺼내는 작업을 하는 클래스 구현
- 기존에 없던 AddCards 메소드 추가
- IEnumerable<CardData> 구현해서 foreach 문에서 순회 기능 추가

Deck 변경
- CardCollection의 상속으로 중복 메소드 제거