### PR TITLE
맵 기본 구조 구현

### DIFF
--- a/Assets/Scripts/Map.meta
+++ b/Assets/Scripts/Map.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3fb5b41aa66a521488119b7703350854
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map/IMovable.cs
+++ b/Assets/Scripts/Map/IMovable.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+
+namespace TeamOdd.Ratocalypse.Map
+{
+    public interface IMovable : IPlaceable
+    {
+        public void MoveTo(int x, int y);
+        public void MoveTo(Vector2Int destination);
+    }
+}

--- a/Assets/Scripts/Map/IMovable.cs.meta
+++ b/Assets/Scripts/Map/IMovable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3b29e2c91fc64f4e8431f104c034bfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map/IPlaceable.cs
+++ b/Assets/Scripts/Map/IPlaceable.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace TeamOdd.Ratocalypse.Map
+{
+    public interface IPlaceable
+    {
+        public Vector2Int Position { get; }
+    }
+}

--- a/Assets/Scripts/Map/IPlaceable.cs.meta
+++ b/Assets/Scripts/Map/IPlaceable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3ef6e538438e3645a655a6e6973da80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map/MapData.cs
+++ b/Assets/Scripts/Map/MapData.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace TeamOdd.Ratocalypse.Map
+{
+    public class MapData
+    {
+        public Vector2Int Size { get; }
+        public List<List<TileData>> Tiles {get;private set;}
+
+        public MapData(Vector2Int size)
+        {
+            Size = size;
+            ResetTiles();
+        }
+
+        public MapData(int width = 8, int height = 8)
+        {
+            Size = new Vector2Int(width, height);
+            ResetTiles();
+        }
+
+        private void ResetTiles()
+        {
+            Tiles = new List<List<TileData>>();
+            for (int x = 0; x < Size.x; x++)
+            {
+                Tiles.Add(new List<TileData>());
+                for (int y = 0; y < Size.y; y++)
+                {
+                    Tiles[x].Add(new TileData(new Vector2Int(x, y)));
+                }
+            }
+        }
+
+        public TileData GetTile(Vector2Int coord)
+        {
+            return Tiles[coord.x][coord.y];
+        }
+
+        public IPlaceable GetPlaceble(Vector2Int coord)
+        {
+            return Tiles[coord.x][coord.y].Placeable;
+        }
+
+        public void SetPlaceble(Vector2Int coord, IPlaceable placeable)
+        {
+            var tileData = GetTile(coord);
+            tileData.SetPlaceable(placeable);
+        }
+
+        public void MovePlaceableTo(Vector2Int movablePosition, Vector2Int destination)
+        {
+            var placeable = GetPlaceble(movablePosition);
+            if(placeable == null || placeable is not IMovable)
+            {
+                throw new System.Exception("No movable at " + movablePosition);
+            }
+
+            var movable = (IMovable)placeable;
+
+            if(GetPlaceble(destination) != null)
+            {
+                throw new System.Exception("Destination " + destination + " is not empty");
+            }
+
+            SetPlaceble(movablePosition, null);
+            SetPlaceble(destination, movable);
+            movable.MoveTo(destination);
+
+        }
+    }
+
+}

--- a/Assets/Scripts/Map/MapData.cs.meta
+++ b/Assets/Scripts/Map/MapData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 790ab348ba378034683df4916923f516
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Map/TileData.cs
+++ b/Assets/Scripts/Map/TileData.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace TeamOdd.Ratocalypse.Map
+{
+    public class TileData
+    {
+        public Vector2Int Coord {get;}
+        public IPlaceable Placeable { get; private set; }
+
+        public TileData(Vector2Int coord, IPlaceable placeable = null)
+        {
+            Coord = coord;
+            Placeable = placeable;
+        }
+
+        public IPlaceable RemovePlaceable()
+        {
+            IPlaceable temp = Placeable;
+            Placeable = null;
+            return temp;
+        }
+
+        public void SetPlaceable(IPlaceable placeable)
+        {
+            Placeable = placeable;
+        }
+    }
+}

--- a/Assets/Scripts/Map/TileData.cs.meta
+++ b/Assets/Scripts/Map/TileData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7f82906da08a3ae4584b7cf6364d34c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
TileData 구현
- IPlaceable과 Coord를 담고 있음
- IMovable은 IPlaceable을 구현하여 모두 TileData에 담길 수 있음.
- 이후에 게임 오브젝트인 Tile의 데이터 처리에 이용될 것.

MapData 구현
- TileData를 담은 클래스로 기본적으로 8x8의 크기를 가지고있음.
- 기본적으로 Get,Set과 관련된 함수를 구현하였음.
- MovePlaceableTo는 타일안의 IMovable을 움직이는 함수임.
  호출부에서 로직이 검증되지 않아 의도치 않은 동작에 대해서는 throw함.