### PR TITLE
메쉬가 sprite의 비율을 유지하게 변경

### DIFF
--- a/Assets/Editor/MeshCreator/MeshCreator.cs
+++ b/Assets/Editor/MeshCreator/MeshCreator.cs
@@ -24,7 +24,7 @@ public class MeshCreator
         {
             Vector2 p = points[i];
             points[i] = new Vector2(p.x / width, p.y / height);
-            Debug.Log(points[i]);
+            //Debug.Log(points[i]);
         }
 
         for (int i = 0; i < points.Count; i++)
@@ -48,10 +48,15 @@ public class MeshCreator
 
         Mesh mesh = new Mesh();
 
-        mesh.vertices = vertices.ToArray();
+        float longestSide = Mathf.Max(width,height);
+
+        mesh.vertices = vertices.ToArray().Select(v =>
+         new Vector3(v.x*width/longestSide, v.y*height/longestSide, v.z)).ToArray();
         mesh.triangles = triangles.ToArray();
         mesh.SetUVs(0, uvs);
         mesh.RecalculateNormals();
+
+
 
         return mesh;
     }

--- a/Assets/Editor/MeshCreator/MeshCreatorWindow.cs
+++ b/Assets/Editor/MeshCreator/MeshCreatorWindow.cs
@@ -33,6 +33,7 @@ public class MeshCreatorWindow : EditorWindow
     private void CreateMesh()
     {
         Mesh mesh = _meshCreator.CreateMesh(_sprite, _thickness);
+        Debug.Log($"Mesh creating thickness: {_thickness}");
         SaveMesh(mesh);
         
     }


### PR DESCRIPTION
생성된 메쉬가 가로 세로중 긴쪽의 최대값이 1이되도록 비율을 유지하게 변경함.