### PR TITLE
Card Command 구현

### DIFF
--- a/Assets/Scripts/Card/Card.cs
+++ b/Assets/Scripts/Card/Card.cs
@@ -12,15 +12,11 @@ namespace TeamOdd.Ratocalypse.Card
         private const float DefaultY = 2.88f;
         private const float DefaultZ = 0.05f;
 
-        [SerializeField]
-        private long _id;
-
-        [SerializeField]
-        private CardDataValue _cardDataValue;
-
         public UnityEvent MouseOverEvents;
         public UnityEvent MouseOutEvents;
         public UnityEvent MouseDragEvents;
+
+        protected CardDataValue _cardDataValue;
 
         public void Awake()
         {
@@ -36,6 +32,11 @@ namespace TeamOdd.Ratocalypse.Card
         public void Update()
         {
             // TODO: implement this...
+        }
+
+        public void AttachDataValue(CardDataValue value)
+        {
+            _cardDataValue = value;
         }
 
         public void OnMouseOver()
@@ -75,25 +76,17 @@ namespace TeamOdd.Ratocalypse.Card
 
         public void Initiate(CardData cardData, bool clone = false)
         {
-            if (clone)
-            {
-                Initiate(cardData.CardDataId, cardData.DataValue.Clone());
-            }
-            else
-            {
-                Initiate(cardData.CardDataId, cardData.DataValue);
-            }
+            Initiate(clone ? cardData.DataValue.Clone() : cardData.DataValue);
         }
 
-        public void Initiate(long id, CardDataValue cardDataValue)
+        public void Initiate(CardDataValue cardDataValue)
         {
-            _id = id;
             _cardDataValue = cardDataValue;
         }
 
         public void DefaultMouseOver()
         {
-            float scale = 1.25f;
+            const float scale = 1.25f;
             SetScale(DefaultX * scale, DefaultY * scale, DefaultZ);
         }
 
@@ -104,14 +97,16 @@ namespace TeamOdd.Ratocalypse.Card
 
         public void DefaultDrag()
         {
-            //Vector2 position = Input.mousePosition;
-            Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
-            float distance = Vector3.Distance(transform.position, Camera.main.transform.position);
+            Camera mainCamera = Camera.main;
+            if (mainCamera == null)
+            {
+                return;
+            }
+            Ray ray = mainCamera.ScreenPointToRay(Input.mousePosition);
+            float distance = Vector3.Distance(transform.position, mainCamera.transform.position);
             Vector3 position = ray.GetPoint(distance);
             position.z = 0.0f;
-            //Debug.Log($"(x: {position.x}, y:{position.y})");
             SetPosition(position);
         }
     }
 }
-

--- a/Assets/Scripts/Card/CardData.cs
+++ b/Assets/Scripts/Card/CardData.cs
@@ -24,14 +24,42 @@ namespace TeamOdd.Ratocalypse.Card
 
     public class CardDataValue
     {
-        public object ValueA { get; set; } = null;
-        public object ValueB { get; set; } = null;
-        public object ValueC { get; set; } = null;
+        public int Cost { get; private set; }
+        public string Title { get; private set; }
+        public string Description { get; private set; }
 
+        public CardDataValue()
+        {
+            Cost = 0;
+            Title = "";
+            Description = "";
+        }
+
+        public CardDataValue(int cost, string title, string description)
+        {
+            Cost = cost;
+            Title = title;
+            Description = description;
+        }
+
+        public void SetCost(int cost)
+        {
+            Cost = cost;
+        }
+
+        public void SetTitle(string title)
+        {
+            Title = title;
+        }
+
+        public void SetDescription(string description)
+        {
+            Description = description;
+        }
 
         public virtual CardDataValue Clone()
         {
-            return new CardDataValue();
+            return new CardDataValue(Cost, Title, Description);
         }
     }
 }

--- a/Assets/Scripts/Card/CardOriginData.cs
+++ b/Assets/Scripts/Card/CardOriginData.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TeamOdd.Ratocalypse.Card
 {
     public class CardOriginData
     {
-        private static readonly object _locker = new object();
-        private static CardOriginData _instance = null;
+        private static CardOriginData _instance;
 
         private readonly Dictionary<long, CardData> _data;
 
@@ -15,14 +15,7 @@ namespace TeamOdd.Ratocalypse.Card
             _data = new Dictionary<long, CardData>();
         }
 
-        public static CardOriginData Instance()
-        {
-            if (_instance == null)
-            {
-                _instance ??= new CardOriginData();
-            }
-            return _instance;
-        }
+        public static CardOriginData Instance => _instance ??= new CardOriginData();
 
         public int Count => _data.Count;
 
@@ -54,12 +47,9 @@ namespace TeamOdd.Ratocalypse.Card
         public bool RemoveDataBy(Func<CardData, bool> filter)
         {
             bool ret = true;
-            foreach (CardData data in _data.Values)
+            foreach (CardData data in _data.Values.Where(filter))
             {
-                if (filter(data))
-                {
-                    ret &= _data.Remove(data.CardDataId);
-                }
+                ret &= _data.Remove(data.CardDataId);
             }
             return ret;
         }
@@ -71,11 +61,11 @@ namespace TeamOdd.Ratocalypse.Card
                 return null;
             }
             CardData data = _data[id];
-            if (data is not TCardData)
+            if (data is not TCardData cardData)
             {
                 throw new InvalidCastException("Cannot cast");
             }
-            return data as TCardData;
+            return cardData;
         }
     }
 }

--- a/Assets/Scripts/Card/Command/AttackCardCommand.cs
+++ b/Assets/Scripts/Card/Command/AttackCardCommand.cs
@@ -1,0 +1,21 @@
+﻿using TeamOdd.Ratocalypse.CreatureLib;
+
+namespace TeamOdd.Ratocalypse.Card
+{
+    public class AttackCardCommand : ICardCommand
+    {
+        private readonly Creature _attacker;
+        private readonly Creature _target;
+
+        public AttackCardCommand(Creature attacker, Creature target)
+        {
+            _attacker = attacker;
+            _target = target;
+        }
+
+        public virtual void Execute()
+        {
+            // TODO: implement this...
+        }
+    }
+}

--- a/Assets/Scripts/Card/Command/AttackCardCommand.cs.meta
+++ b/Assets/Scripts/Card/Command/AttackCardCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 30a5e5256b734fe0a111428844372e57
+timeCreated: 1690274411

--- a/Assets/Scripts/Card/Command/MoveCardCommand.cs
+++ b/Assets/Scripts/Card/Command/MoveCardCommand.cs
@@ -1,0 +1,21 @@
+﻿using UnityEngine;
+
+namespace TeamOdd.Ratocalypse.Card
+{
+    public class MoveCardCommand : ICardCommand
+    {
+        protected readonly Vector2Int _start;
+        protected readonly Vector2Int _dest;
+
+        public MoveCardCommand(Vector2Int start, Vector2Int dest)
+        {
+            _start = start;
+            _dest = dest;
+        }
+
+        public virtual void Execute()
+        {
+            // TODO: implement this...
+        }
+    }
+}

--- a/Assets/Scripts/Card/Command/MoveCardCommand.cs.meta
+++ b/Assets/Scripts/Card/Command/MoveCardCommand.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c2262f6370384b51bcd5675ac9a5b4ec
+timeCreated: 1690254091

--- a/Assets/Scripts/Card/ICardCommand.cs
+++ b/Assets/Scripts/Card/ICardCommand.cs
@@ -1,0 +1,7 @@
+namespace TeamOdd.Ratocalypse.Card
+{
+    public interface ICardCommand
+    {
+        void Execute();
+    }
+}

--- a/Assets/Scripts/Card/ICardCommand.cs.meta
+++ b/Assets/Scripts/Card/ICardCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09606093f02840646a5500d3b4c531f3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Card/MoveOrAttackCardData.cs
+++ b/Assets/Scripts/Card/MoveOrAttackCardData.cs
@@ -8,6 +8,11 @@ namespace TeamOdd.Ratocalypse.Card
         {
             RangeType = rangeType;
         }
+
+        public override CardData Clone()
+        {
+            return new MoveOrAttackCardData(CardDataId, RangeType);
+        }
     }
 
     public enum MoveOrAttackRangeType


### PR DESCRIPTION
CardDataValue 변경
- 기존에 임의로 작성한 object ValueA, ValueB, ValueC를 각각 int Cost, string Title, string Description으로 변경함
- 각각 카드 기술 코스트, 카드 제목, 카드 설명에 해당함
- SetCost, SetTitle, SetDescription 메소드로 추가적인 변경이 가능하도록 설계

Card
- CardData에 있는 id로도 충분하다 판단돼, Card에 중복해서 있는 id 필드 제거

CardOriginData
- lock 제거할 때 미처 제거하지 않은 object _locker 제거함

ICardCommand
- Execute() 메소드로 카드의 효과를 발동하도록 하는 기본 인터페이스
- MoveCardCommand와 AttackCardCommand도 생성하고 메소드는 비워둔 상태

MoveOrAttackCardData
- Clone 메소드 구현